### PR TITLE
Including white source bolt

### DIFF
--- a/BuildStage.yaml
+++ b/BuildStage.yaml
@@ -25,6 +25,9 @@ stages:
         tags: |
           ${{ parameters.tag}}
           
+    - task: WhiteSource Bolt@20
+      displayName: 'WhiteSource Bolt'
+          
     - upload: ${{ parameters.name }}/helm
       artifact: ${{ parameters.name }}/helm
 


### PR DESCRIPTION
Including white source task post build and before publish of artifacts so that the relevant white source report is generated.